### PR TITLE
Prefer using PyObject_GenericGetDict to get the __dict__

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -126,6 +126,14 @@ Object Protocol
    A generic implementation for the getter of a ``__dict__`` descriptor. It
    creates the dictionary if necessary.
 
+   This function may also be called to get the :py:attr:`~object.__dict__`
+   of the object *o*. Pass ``NULL`` for *context* when calling it.
+   Since this function may need to allocate memory for theg
+   dictionary, it is may be more efficient to call :c:func:`PyObject_GetAttr`
+   when accessing an attribute on the object.
+
+   On failure, returns ``NULL`` with an exception set.
+
    .. versionadded:: 3.3
 
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1710,8 +1710,8 @@ and :c:type:`PyType_Type` effectively act as defaults.)
    at the very end of the structure.
 
    The :c:member:`~PyTypeObject.tp_dictoffset` should be regarded as write-only.
-   To get the pointer to the dictionary call :c:func:`_PyObject_GetDictPtr`.
-   Calling :c:func:`_PyObject_GetDictPtr` may need to allocate memory for the
+   To get the pointer to the dictionary call :c:func:`PyObject_GenericGetDict`.
+   Calling :c:func:`PyObject_GenericGetDict` may need to allocate memory for the
    dictionary, so it is may be more efficient to call :c:func:`PyObject_GetAttr`
    when accessing an attribute on the object.
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1079,7 +1079,11 @@ _PyObject_ComputedDictPointer(PyObject *obj)
 
 /* Helper to get a pointer to an object's __dict__ slot, if any.
  * Creates the dict from inline attributes if necessary.
- * Does not set an exception. */
+ * Does not set an exception.
+ *
+ * Note that the tp_dictoffset docs used to recommend this function,
+ * so it should be treated as part of the public API.
+ */
 PyObject **
 _PyObject_GetDictPtr(PyObject *obj)
 {


### PR DESCRIPTION
See https://github.com/python/cpython/pull/95598

I might be missing a detail, but this seems better than recommending/documenting `_PyObject_GetDictPtr`.